### PR TITLE
chore: add patch for go version to 1.23 downstream

### DIFF
--- a/.konflux/patches/0000-go1.23.patch
+++ b/.konflux/patches/0000-go1.23.patch
@@ -1,26 +1,13 @@
 diff --git a/go.mod b/go.mod
-index 95210aac..651831cf 100644
+index 0e9c75b2..5e10e994 100644
 --- a/go.mod
 +++ b/go.mod
-@@ -2,7 +2,7 @@ module github.com/openshift-pipelines/pipelines-as-code
+@@ -2,8 +2,6 @@ module github.com/openshift-pipelines/pipelines-as-code
  
  go 1.23.8
  
 -toolchain go1.24.2
-+toolchain go1.23
- 
+-
  require (
- 	code.gitea.io/gitea v1.23.7
-diff --git a/vendor/modules.txt b/vendor/modules.txt
-index cf4331dd..42754839 100644
---- a/vendor/modules.txt
-+++ b/vendor/modules.txt
-@@ -58,7 +58,7 @@ github.com/census-instrumentation/opencensus-proto/gen-go/metrics/v1
- github.com/census-instrumentation/opencensus-proto/gen-go/resource/v1
- github.com/census-instrumentation/opencensus-proto/gen-go/trace/v1
- # github.com/cert-manager/cert-manager v1.17.2
--## explicit; go 1.23.8
-+## explicit; go 1.23.6
- github.com/cert-manager/cert-manager/pkg/apis/acme
- github.com/cert-manager/cert-manager/pkg/apis/acme/v1
- github.com/cert-manager/cert-manager/pkg/apis/certmanager
+        code.gitea.io/gitea v1.23.7
+        code.gitea.io/sdk/gitea v0.21.0


### PR DESCRIPTION
the go rhel builder supported image does not allow us to build with 1.24 right now because of which we are patching the upstream patch with 1.23 golang to help pac use the supported version.