### PR TITLE
chore(KONFLUX-6210): fix and set name and cpe label for pac-downstream-1-19-controller

### DIFF
--- a/.konflux/dockerfiles/controller.Dockerfile
+++ b/.konflux/dockerfiles/controller.Dockerfile
@@ -26,6 +26,7 @@ LABEL \
       com.redhat.component="openshift-pipelines-pipelines-as-code-controller-container" \
       name="openshift-pipelines/pipelines-pipelines-as-code-controller-rhel9" \
       version=$VERSION \
+      cpe="cpe:/a:redhat:openshift_pipelines:1.19::el9" \
       summary="Red Hat OpenShift Pipelines Pipelines as Code Controller" \
       maintainer="pipelines-extcomm@redhat.com" \
       description="Red Hat OpenShift Pipelines Pipelines as Code Controller" \


### PR DESCRIPTION
For https://issues.redhat.com/browse/KONFLUX-6210, clair needs access to a name and cpe label that it can use to look up the image in VEX statements.

See also release-engineering/rhtap-ec-policy#149

Signed-off-by: Ralph Bean <rbean@redhat.com>
Assisted-by: Gemini
