### PR TITLE
chore(KONFLUX-6210): fix and set name and cpe label for pac-downstream-1-18-cli

### DIFF
--- a/.konflux/dockerfiles/cli.Dockerfile
+++ b/.konflux/dockerfiles/cli.Dockerfile
@@ -21,7 +21,8 @@ COPY --from=builder /tmp/tkn-pac /usr/bin
 
 LABEL \
       com.redhat.component="openshift-pipelines-cli-tkn-pac-container" \
-      name="openshift-pipelines/pipelines-cli-tkn-pac-rhel9" \
+      name="openshift-pipelines/pipelines-pipelines-as-code-cli-rhel9" \
+      cpe="cpe:/a:redhat:openshift_pipelines:1.18::el9" \
       version=$VERSION \
       summary="Red Hat OpenShift pipelines tkn pac CLI" \
       maintainer="pipelines-extcomm@redhat.com" \


### PR DESCRIPTION
For https://issues.redhat.com/browse/KONFLUX-6210, clair needs access to a name and cpe label that it can use to look up the image in VEX statements.

See also release-engineering/rhtap-ec-policy#149

Signed-off-by: Ralph Bean <rbean@redhat.com>
Assisted-by: Gemini
