### PR TITLE
chore(KONFLUX-6210): fix and set name and cpe label for pac-downstream-1-15-controller

### DIFF
--- a/.konflux/dockerfiles/controller.Dockerfile
+++ b/.konflux/dockerfiles/controller.Dockerfile
@@ -28,6 +28,7 @@ LABEL \
       summary="Red Hat OpenShift Pipelines Pipelines as Code Controller" \
       maintainer="pipelines-extcomm@redhat.com" \
       description="Red Hat OpenShift Pipelines Pipelines as Code Controller" \
+      cpe="cpe:/a:redhat:openshift_pipelines:1.15::el8" \
       io.k8s.display-name="Red Hat OpenShift Pipelines Pipelines as Code Controller" \
       io.k8s.description="Red Hat OpenShift Pipelines Pipelines as Code Controller" \
       io.openshift.tags="pipelines,tekton,openshift"


### PR DESCRIPTION
For https://issues.redhat.com/browse/KONFLUX-6210, clair needs access to a name and cpe label that it can use to look up the image in VEX statements.

See also release-engineering/rhtap-ec-policy#149

Signed-off-by: Ralph Bean <rbean@redhat.com>
Assisted-by: Gemini
