### PR TITLE
chore(KONFLUX-6210): fix and set name and cpe label for pac-downstream-1-14-watcher

### DIFF
--- a/.konflux/dockerfiles/watcher.Dockerfile
+++ b/.konflux/dockerfiles/watcher.Dockerfile
@@ -23,7 +23,8 @@ COPY head ${KO_DATA_PATH}/HEAD
 
 LABEL \
       com.redhat.component="openshift-pipelines-pipelines-as-code-watcher-container" \
-      name="openshift-pipelines/pipelines-as-code-watcher-rhel8" \
+      name="openshift-pipelines/pipelines-pipelines-as-code-watcher-rhel8" \
+      cpe="cpe:/a:redhat:openshift_pipelines:1.14::el8" \
       version=$VERSION \
       summary="Red Hat OpenShift Pipelines Pipelines as Code Watcher" \
       maintainer="pipelines-extcomm@redhat.com" \


### PR DESCRIPTION
For https://issues.redhat.com/browse/KONFLUX-6210, clair needs access to a name and cpe label that it can use to look up the image in VEX statements.

See also release-engineering/rhtap-ec-policy#149

Signed-off-by: Ralph Bean <rbean@redhat.com>
Assisted-by: Gemini
